### PR TITLE
add new tag by BioC request

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,5 @@ biocViews:
     DifferentialExpression,
     Sequencing,
     Microarray,
-    RNASeq
+    RNASeq,
+    ImmunoOncology


### PR DESCRIPTION
* adds the `ImmunoOncology` tag to `BiocViews` section of `DESCRIPTION`, as per request from the Bioconductor team