### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ r_packages:
   - BiocManager
 
 r_github_packages:
-  - r-lib/devtools
   - r-lib/sessioninfo
   - jimhester/covr
   - nhejazi/biotmleData

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary
+  - C:\RLibrary -> appveyor.yml
 
 # Adapt as necessary starting from here
 branches:
@@ -29,7 +29,6 @@ environment:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github r-lib/devtools
   - travis-tool.sh install_github jimhester/covr
   - travis-tool.sh install_github nhejazi/biotmleData
   - travis-tool.sh install_bioc BiocCheck


### PR DESCRIPTION
Fix CI builds by using CRAN version of [`devtools`](https://cran.r-project.org/web/packages/devtools/index.html).